### PR TITLE
Switched the way that Property is type checked in exercise #05

### DIFF
--- a/exercises/05_properties/exercise.js
+++ b/exercises/05_properties/exercise.js
@@ -8,7 +8,7 @@ var run = {
 
   expect: function (stream, exercise, assert) {
     var expectedValue = 10 + 11 + 12 + 13;
-    var isProperty = !!stream.onValue && !stream.toProperty;
+    var isProperty = stream instanceof Bacon.Property;
 
     if (!isProperty) {
       exercise.emit('fail', 'Returned value has to be a property.')


### PR DESCRIPTION
It seems that `bacon.Property` has the method `toProperty` so this Exercise will always fail.

I've switched it to check using `instanceof` which will be `true` if it's a `bacon.Property` if it's an `EventStream` it will be `false`.