### PR TITLE
Fix exercises

### DIFF
--- a/exercises/02_wrapping_values_as_reactive_datatypes/problem.md
+++ b/exercises/02_wrapping_values_as_reactive_datatypes/problem.md
@@ -40,7 +40,8 @@ Inputs are given in the following order:
 
 1. `promise` - A promise that should be wrapped to as a reactive datatype
 2. `eventTarget` - an EventTarget object that emits data on a `data` channel.
-3. `callback` - A callback which when called should give a value on an event stream
+3. `callback` - A function which expects to be called with `'foo', 'bar', cb`, whose
+call to `cb` should be emitted on an event stream.
 
 **In addition** to these values, you should create an event source that emits all
 the values in an array. The array should have 4 incremented values starting with `1`.

--- a/exercises/06_map_and_filter/problem.md
+++ b/exercises/06_map_and_filter/problem.md
@@ -67,10 +67,10 @@ strategical pieces of information:
 passes the sensor.
 - A property which reads the current threat level based on the distance of the
 Zrrk Planet Destroyer.
-  - Low threat for `x>5`.
-  - Medium threat for `5=>x>2`.
-  - High threat for `2=>x>=1`.
-  - Extreme threat for `x<1`.
+  - `'low'` threat for `x>5`.
+  - `'medium'` threat for `5=>x>2`.
+  - `'high'` threat for `2=>x>=1`.
+  - `'extreme'` threat for `x<1`.
 - A stream which emits a 1 for Zrrk ships and a 0 for all other ships which
 passes the sensor, but only after we have achieved extreme threat.
 

--- a/exercises/09_combining_observables_part_ii/problem.md
+++ b/exercises/09_combining_observables_part_ii/problem.md
@@ -46,10 +46,10 @@ in peace. The EDF have decided that in order to show signs of good will
 towards the apparently friendly Zrrk to broadcast the withdrawal status of the
 EDF fleet.
 
-The solar system is divided into five sectors, with EDF ships being deployed
-in sector one through four. Your final assignment will be to provide a report
-for the Zrrk commander on the current status of deployed EDF ships in all five
-sectors of the solar system.
+The solar system is divided into five sectors, each named `sectorX` where `X`
+is the sector number, with EDF ships being deployed in sector one through four.
+Your final assignment will be to provide a report for the Zrrk commander on the
+current status of deployed EDF ships in all five sectors of the solar system.
 
 ## Template
 

--- a/exercises/09_combining_observables_part_ii/solution/solution.js
+++ b/exercises/09_combining_observables_part_ii/solution/solution.js
@@ -1,5 +1,3 @@
-var Bacon = require('baconjs');
-
 module.exports = function (Bacon, sector1Count, sector2Count, sector3Count, sector4Count) {
   return Bacon.combineTemplate({
     sector1: sector1Count,

--- a/exercises/12_selective_data_by_timing/problem.md
+++ b/exercises/12_selective_data_by_timing/problem.md
@@ -2,8 +2,8 @@
 
 You can alter the timing of streams by distributing values over
 different times, delaying values, or end streams based on a predicate.
-We've seen some usage of `.take()` and `.takeWhile()` back in exercise
-07. Fold and Scan, but we'll go more in depth of timing functions
+We've seen some usage of `.take()` and `.takeWhile()` back in
+exercise 07. Fold and Scan, but we'll go more in depth of timing functions
 in this exercise.
 
 Like in many functional programming libraries or even in jQuery, you
@@ -51,8 +51,8 @@ true, values will be taken from the observable, the moment it returns
 Following the example of the river Nidelva in Trondheim, Norway,
 we need to take samples of water quality. We want to take a sample
 every `sampleTime` milliseconds (not before), but only as long as the system
-is turned on. You can assume that you the given function
-(parameter `untilSwitchTurnedOff`) holds true as long as the system
+is turned on. You can assume that the given function parameter
+`untilSwitchTurnedOff` holds true as long as the system
 is active and the water samples should be taken. The first water sample
 should be included in your resulting stream.
 

--- a/exercises/13_flatmaps/problem.md
+++ b/exercises/13_flatmaps/problem.md
@@ -4,7 +4,7 @@ If you have several sources with similar data or want to create
 a new stream based on values in a stream, you can do that. `flatMap`
 is a combinator that allows you to take a function and spawn a new
 EventStream based on an Observable. So `observable.flatMap(fn)`, can
-generate a new EventStream with the values from a EventStream created
+generate a new EventStream with the values from an EventStream created
 in the function `fn`. This is extremely powerful, but can be hard to
 grasp at first.
 
@@ -23,8 +23,8 @@ stream:  10-10-10--50--50--50---100---100---100--->
 ```
 
 With some delay trickery we can clearly see that the EventStreams
-inside the function passed to `flatMap`, is flattened and all it's
-values becomes a part of a new EventStream.
+inside the function passed to `flatMap`, are flattened and all their
+values become part of a new EventStream.
 
 Another way of using `flatMap` is to transform and select data in
 one simple step (map and filter):

--- a/exercises/13_flatmaps/problem.md
+++ b/exercises/13_flatmaps/problem.md
@@ -97,7 +97,7 @@ We need to take the data specialist stream of tuples and transform it
 to a linear stream (with duplicate values where the number of samples is `> 1`).
 
 **Note**: We are only interested in the data points where the water level
-is below the average water level in Nidelva (`200 000` liters).
+is above the average water level in Nidelva (`200 000` liters).
 
 
 

--- a/exercises/13_flatmaps/problem.md
+++ b/exercises/13_flatmaps/problem.md
@@ -110,7 +110,7 @@ is above the average water level in Nidelva (`200 000` liters).
 
 
 ### Output
- - EventStream with liters from Nidelva. E.g. [190000, 180000, etc]
+ - EventStream with whole liters from Nidelva. E.g. [190000, 180000, etc]
 
 
 ## Template

--- a/exercises/14_field_and_form_validation/exercise.js
+++ b/exercises/14_field_and_form_validation/exercise.js
@@ -111,6 +111,19 @@ var testing = {
       unsub();
     }
   },
+  'Field B should be valid after invalid, then empty input': {
+    input: run.input,
+    expect: function (streams, ex, assert) {
+      var unsub = streams.fieldBValid
+        .sampledBy(fieldB)
+        .skip(1)
+        .onValue(assert);
+
+      fieldB.push('asd');
+      fieldB.push();
+      unsub();
+    }
+  },
   'Field B should be valid with valid input': {
     input: run.input,
     expect: function (streams, ex, assert) {

--- a/exercises/14_field_and_form_validation/solution/solution.js
+++ b/exercises/14_field_and_form_validation/solution/solution.js
@@ -1,6 +1,6 @@
 module.exports = function (Bacon, fieldA, validationA, fieldB, validationB, fieldC, validationC) {
   var a = fieldA.map(validationA).toProperty(false);
-  var b = fieldB.filter(Boolean).map(validationB).toProperty(true);
+  var b = fieldB.map(function (value) { return value ? validationB(value) : true; }).toProperty(true);
   var c = fieldC.map(validationC).toProperty(false);
 
   var form = a.and(b).and(c);


### PR DESCRIPTION
This brings fixes to some of the exercises, which had either of:

* discrepancies between what the problem description said and the proposed solution did,
* unclear instructions regarding for example expected property names (which forced you to look at the solution to finish the task),
* grammar / typo mistakes in the problem description,
* or some other opportunity for improvement.