### PR TITLE
Use only Node.js >=4, no Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ observables).
 
 ## Install and Start
 
+You need Node.js at least version 4.
+
 Install the workshop by doing
 ```
 npm install -g bacon-love

--- a/enforce-node-version.js
+++ b/enforce-node-version.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var semver = require('semver');
+var requiredNodeVersion = require('./package.json').engines.node;
+
+module.exports = function () {
+    var isOkNodeVersion = semver.satisfies(process.versions.node, requiredNodeVersion);
+    if (!isOkNodeVersion) {
+        console.error('bacon-love needs Node.js version ' + requiredNodeVersion + ', but found ' +
+            'to be running Node.js ' + process.version);
+        process.exit(1);
+    }
+};

--- a/exercises/01_intro_to_the_workshop/problem.md
+++ b/exercises/01_intro_to_the_workshop/problem.md
@@ -61,7 +61,7 @@ With a few exceptions the template to use for all exercises will be the followin
 
 ```javascript
 // expose the stream generator as a module method
-export default (Bacon, input1, input2 /* , ..., inputN */ ) => {
+module.exports = (Bacon, input1, input2 /* , ..., inputN */ ) => {
   // return resulting stream
 };
 ```

--- a/exercises/01_intro_to_the_workshop/solution/solution.js
+++ b/exercises/01_intro_to_the_workshop/solution/solution.js
@@ -1,1 +1,1 @@
-export default Bacon => Bacon.sequentially(100, [1, 2, 3]);
+module.exports = Bacon => Bacon.sequentially(100, [1, 2, 3]);

--- a/exercises/02_wrapping_values_as_reactive_datatypes/problem.md
+++ b/exercises/02_wrapping_values_as_reactive_datatypes/problem.md
@@ -55,7 +55,7 @@ streams, with the keys as defined in the template below.
 
 ```javascript
 // expose the stream generator as a module method
-export default (Bacon, promise, eventTarget, callback) => {
+module.exports = (Bacon, promise, eventTarget, callback) => {
   return {
     promise: void 0,     // return your promise implementation here
     eventTarget: void 0, // return your eventTarget implementation here

--- a/exercises/02_wrapping_values_as_reactive_datatypes/solution/solution.js
+++ b/exercises/02_wrapping_values_as_reactive_datatypes/solution/solution.js
@@ -1,5 +1,5 @@
 // Export method taking in the correct arguments.
-export default (Bacon, promise, eventTarget, callback) => ({
+module.exports = (Bacon, promise, eventTarget, callback) => ({
     // When the promise is resolved a value is sent through the event stream
     // created from Bacon.fromPromise
     promise: Bacon.fromPromise(promise),

--- a/exercises/03_subscription_based/problem.md
+++ b/exercises/03_subscription_based/problem.md
@@ -42,7 +42,7 @@ but the original stream.
 
 ```js
 // expose the stream generator as a module method
-export default (Bacon, stream, action, actionOnValue) => {
+module.exports = (Bacon, stream, action, actionOnValue) => {
   /**
    * Your code
    */

--- a/exercises/03_subscription_based/solution/solution.js
+++ b/exercises/03_subscription_based/solution/solution.js
@@ -1,5 +1,5 @@
 // Export method taking in the correct arguments.
-export default (Bacon, stream, action, actionOnValue) => {
+module.exports = (Bacon, stream, action, actionOnValue) => {
     stream
         .doAction(action)
         .log('Value:')

--- a/exercises/04_eventstreams/problem.md
+++ b/exercises/04_eventstreams/problem.md
@@ -70,7 +70,7 @@ to do the timing of the data.
 Return created stream
 ```js
 // Export method as a module.
-export default (Bacon) => {
+module.exports = (Bacon) => {
   /**
    * Your code here
    **/

--- a/exercises/04_eventstreams/solution/solution.js
+++ b/exercises/04_eventstreams/solution/solution.js
@@ -1,5 +1,5 @@
 // Export method taking in the correct arguments.
-export default Bacon => {
+module.exports = Bacon => {
     const bus = Bacon.Bus();
     setTimeout(() => bus.push('Bacon'), 100);
     setTimeout(() => bus.push('is'), 200);

--- a/exercises/05_properties/problem.md
+++ b/exercises/05_properties/problem.md
@@ -44,7 +44,7 @@ number sequence: `10 -> 11 -> 12 -> 13`.
 Return created stream
 ```js
 // Export method as a module.
-export default (Bacon) => {
+module.exports = (Bacon) => {
   /**
    * Your code here
    **/

--- a/exercises/05_properties/solution/solution.js
+++ b/exercises/05_properties/solution/solution.js
@@ -1,2 +1,2 @@
 // Export method taking in the correct arguments.
-export default Bacon => Bacon.sequentially(10, [11, 12, 13]).toProperty(10);
+module.exports = Bacon => Bacon.sequentially(10, [11, 12, 13]).toProperty(10);

--- a/exercises/06_map_and_filter/problem.md
+++ b/exercises/06_map_and_filter/problem.md
@@ -86,7 +86,7 @@ Ships entering the solar system will have this information:
 
 
 ```js
-export default (Bacon, enteringShips, destroyerPosition) => {
+module.exports = (Bacon, enteringShips, destroyerPosition) => {
   return {
     ships: void 0,           // Your ship counter goes here
     threat: void 0,          // Your threat level goes here

--- a/exercises/06_map_and_filter/solution/solution.js
+++ b/exercises/06_map_and_filter/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, enteringShips, destroyerPosition) => {
+module.exports = (Bacon, enteringShips, destroyerPosition) => {
     const ships = enteringShips.map(ship => ship.type === 'zrrk' ? 1 : 0);
 
     const threat = destroyerPosition.map(distance => {

--- a/exercises/07_fold_and_scan/problem.md
+++ b/exercises/07_fold_and_scan/problem.md
@@ -77,7 +77,7 @@ The sensors are the same as the previous exercise.
 ## Template
 
 ```js
-export default (Bacon, enteringShips, destroyerPosition) => {
+module.exports = (Bacon, enteringShips, destroyerPosition) => {
   /**
    * Your code here
    */

--- a/exercises/07_fold_and_scan/solution/solution.js
+++ b/exercises/07_fold_and_scan/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, enteringShips, destroyerPosition) => {
+module.exports = (Bacon, enteringShips, destroyerPosition) => {
     const shipTally = enteringShips
         .filter(ship => ship.type === 'zrrk')
         .map(1)

--- a/exercises/08_combining_observables_part_i/problem.md
+++ b/exercises/08_combining_observables_part_i/problem.md
@@ -90,7 +90,7 @@ parameter a tuple on the form `[message, key]`.
 ## Template
 
 ```js
-export default (Bacon, messages, keys, decoderFunction) => {
+module.exports = (Bacon, messages, keys, decoderFunction) => {
   const streamOfDecodedMessages;
 
   return streamOfDecodedMessages;

--- a/exercises/08_combining_observables_part_i/solution/solution.js
+++ b/exercises/08_combining_observables_part_i/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, messages, keys, decoderFunction) =>
+module.exports = (Bacon, messages, keys, decoderFunction) =>
     messages
         .zip(keys)
         .map(decoderFunction);

--- a/exercises/09_combining_observables_part_ii/problem.md
+++ b/exercises/09_combining_observables_part_ii/problem.md
@@ -54,7 +54,7 @@ current status of deployed EDF ships in all five sectors of the solar system.
 ## Template
 
 ```js
-export default (Bacon, sector1Count, sector2Count, sector3Count, sector4Count) => {
+module.exports = (Bacon, sector1Count, sector2Count, sector3Count, sector4Count) => {
   const deploymentReport;
 
   return deploymentReport;

--- a/exercises/09_combining_observables_part_ii/solution/solution.js
+++ b/exercises/09_combining_observables_part_ii/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, sector1Count, sector2Count, sector3Count, sector4Count) =>
+module.exports = (Bacon, sector1Count, sector2Count, sector3Count, sector4Count) =>
     Bacon.combineTemplate({
         sector1: sector1Count,
         sector2: sector2Count,

--- a/exercises/10_and_or_or_or_maybe_not/problem.md
+++ b/exercises/10_and_or_or_or_maybe_not/problem.md
@@ -55,7 +55,7 @@ if the report system should be triggered.
 ## Template
 
 ```js
-export default (Bacon, riverFlow, inCriticalMode, isOnBreak, isSingleGate, systemActive, riverFlowLimit) => {
+module.exports = (Bacon, riverFlow, inCriticalMode, isOnBreak, isSingleGate, systemActive, riverFlowLimit) => {
   /**
    * Your code here
    **/

--- a/exercises/10_and_or_or_or_maybe_not/solution/solution.js
+++ b/exercises/10_and_or_or_or_maybe_not/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, riverFlow, inCriticalMode, isOnBreak, isSingleGate, systemActive, riverFlowLimit) => {
+module.exports = (Bacon, riverFlow, inCriticalMode, isOnBreak, isSingleGate, systemActive, riverFlowLimit) => {
     const isTooMuchWater = riverFlow
         .map(flow => flow > riverFlowLimit)
         .toProperty();

--- a/exercises/11_sampled/problem.md
+++ b/exercises/11_sampled/problem.md
@@ -65,7 +65,7 @@ An EventStream of the water level samples.
 ## Template
 
 ```js
-export default (Bacon, nidelva, leirelva, buttonClicked) => {
+module.exports = (Bacon, nidelva, leirelva, buttonClicked) => {
   /**
    * Your code here
    **/

--- a/exercises/11_sampled/solution/solution.js
+++ b/exercises/11_sampled/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, nidelva, leirelva, buttonClicked) =>
+module.exports = (Bacon, nidelva, leirelva, buttonClicked) =>
     nidelva
         .combine(leirelva, (leirelvaSample, nidelvaSample) => leirelvaSample + nidelvaSample)
         .sampledBy(buttonClicked);

--- a/exercises/12_selective_data_by_timing/problem.md
+++ b/exercises/12_selective_data_by_timing/problem.md
@@ -67,7 +67,7 @@ should be included in your resulting stream.
 ## Template
 
 ```js
-export default (Bacon, riverQuality, untilSwitchTurnedOff, sampleTime) => {
+module.exports = (Bacon, riverQuality, untilSwitchTurnedOff, sampleTime) => {
   /**
    * Your code here
    **/

--- a/exercises/12_selective_data_by_timing/solution/solution.js
+++ b/exercises/12_selective_data_by_timing/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, riverQuality, untilSwitchTurnedOff, sampleTime) =>
+module.exports = (Bacon, riverQuality, untilSwitchTurnedOff, sampleTime) =>
     riverQuality
         .debounceImmediate(sampleTime)
         .takeWhile(untilSwitchTurnedOff);

--- a/exercises/13_flatmaps/problem.md
+++ b/exercises/13_flatmaps/problem.md
@@ -116,7 +116,7 @@ is above the average water level in Nidelva (`200 000` liters).
 ## Template
 
 ```js
-export default (Bacon, riverFlowInCubicFeet, litresInCubicFeet) => {
+module.exports = (Bacon, riverFlowInCubicFeet, litresInCubicFeet) => {
   /**
    * Your code here
    **/

--- a/exercises/13_flatmaps/solution/solution.js
+++ b/exercises/13_flatmaps/solution/solution.js
@@ -1,6 +1,9 @@
-export default (Bacon, riverFlowInCubicFeet, litresInCubicFeet) =>
+module.exports = (Bacon, riverFlowInCubicFeet, litresInCubicFeet) =>
     riverFlowInCubicFeet
-        .flatMap(([cubicFeet, numberOfSamples]) => {
+        .flatMap(tuple => {
+            const cubicFeet = tuple[0];
+            const numberOfSamples = tuple[1];
+            
             const litres = Math.round(cubicFeet * litresInCubicFeet);
 
             if (litres > 200000) {

--- a/exercises/14_field_and_form_validation/problem.md
+++ b/exercises/14_field_and_form_validation/problem.md
@@ -36,7 +36,7 @@ be valid.
 ## Template
 
 ```js
-export default (Bacon, fieldA, validationA, fieldB, validationB, fieldC, validationC) => {
+module.exports = (Bacon, fieldA, validationA, fieldB, validationB, fieldC, validationC) => {
   return {
     fieldAValid: void 0, //The validity of field A
     fieldBValid: void 0, //The validity of field B

--- a/exercises/14_field_and_form_validation/solution/solution.js
+++ b/exercises/14_field_and_form_validation/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, fieldA, validationA, fieldB, validationB, fieldC, validationC) => {
+module.exports = (Bacon, fieldA, validationA, fieldB, validationB, fieldC, validationC) => {
     const a = fieldA.map(validationA).toProperty(false);
     const b = fieldB.map(value => value ? validationB(value) : true).toProperty(true);
     const c = fieldC.map(validationC).toProperty(false);

--- a/exercises/15_loading_spinner/problem.md
+++ b/exercises/15_loading_spinner/problem.md
@@ -17,7 +17,7 @@ waiting for the result of an async operation.
 ## Template
 
 ```js
-export default (Bacon, clicks, startAsyncTask) => {
+module.exports = (Bacon, clicks, startAsyncTask) => {
   const spinnerVisibility;
 
   return spinnerVisibility;

--- a/exercises/15_loading_spinner/solution/solution.js
+++ b/exercises/15_loading_spinner/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, clicks, startAsyncTask) => {
+module.exports = (Bacon, clicks, startAsyncTask) => {
     const request = clicks.map(true);
     const response = request.flatMap(startAsyncTask);
 

--- a/exercises/16_error_handling/problem.md
+++ b/exercises/16_error_handling/problem.md
@@ -26,7 +26,7 @@ observable can be used to for instance show an error-message.
 ## Template
 
 ```js
-export default (Bacon, asyncTask) => {
+module.exports = (Bacon, asyncTask) => {
   const showErrorMessage;
 
   return showErrorMessage;

--- a/exercises/16_error_handling/solution/solution.js
+++ b/exercises/16_error_handling/solution/solution.js
@@ -1,4 +1,4 @@
-export default (Bacon, asyncTask) =>
+module.exports = (Bacon, asyncTask) =>
     asyncTask
         .map(false)
         .mapError(true)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('./enforce-node-version')();
+
 const workshopper = require('workshopper');
 const join = require('path').join;
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,7 @@
     "test": "mocha"
   },
   "author": "",
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "babel-core": "^6.10.4",
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "devDependencies": {
     "faithful-exec": "^0.1.0",
     "mocha": "^2.5.3"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.10.4",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.9.0",
     "baconjs": "^0.7.84",
     "lodash": "^4.13.1",
     "q": "^1.4.1",

--- a/test/test-correct-node-version.js
+++ b/test/test-correct-node-version.js
@@ -1,0 +1,12 @@
+var assert = require('assert');
+var semver = require('semver');
+var requiredNodeVersion = require('../package.json').engines.node;
+
+describe('Node.js', function () {
+    it('is version ' + requiredNodeVersion, function () {
+        assert(
+            semver.satisfies(process.version, requiredNodeVersion),
+            'Node.js is ' + process.version + ', but needs to be version ' + requiredNodeVersion
+        );
+    })
+});

--- a/verify.js
+++ b/verify.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var semver = require('semver');
-var canUseES2015 = semver.satisfies(process.versions.node, '>=4');
-if (canUseES2015) {
-  require('babel-core/register')({
-    presets: [require('babel-preset-es2015')],
-    plugins: [require('babel-plugin-add-module-exports')]
-  });
-}
+require('./enforce-node-version')();
+
+require('babel-core/register')({
+  presets: [require('babel-preset-es2015')],
+  plugins: [require('babel-plugin-add-module-exports')]
+});
 
 var path = require('path');
 
@@ -43,7 +41,7 @@ module.exports = function (tests, testRun, options) {
     }
 
     if(typeof usersolution !== 'function'){
-      this.emit('fail', 'You should always return a function using module.exports' + (canUseES2015 ? ' or export default.' : '.'));
+      this.emit('fail', 'You should always return a function using module.exports or export default.');
       return callback(null, false);
     }
 

--- a/verify.js
+++ b/verify.js
@@ -2,11 +2,6 @@
 
 require('./enforce-node-version')();
 
-require('babel-core/register')({
-  presets: [require('babel-preset-es2015')],
-  plugins: [require('babel-plugin-add-module-exports')]
-});
-
 var path = require('path');
 
 var _ = require('lodash');
@@ -41,7 +36,7 @@ module.exports = function (tests, testRun, options) {
     }
 
     if(typeof usersolution !== 'function'){
-      this.emit('fail', 'You should always return a function using module.exports or export default.');
+      this.emit('fail', 'You should always return a function using module.exports.');
       return callback(null, false);
     }
 


### PR DESCRIPTION
This fixes #10 by enforcing the use of Node.js >=4, and only teaches language constructs available in vanilla Node.js >=4.

Specifically, without Babel this means we change `export default` everywhere to `module.exports =`.